### PR TITLE
adds example of using Cypress type definitions and cy.visit

### DIFF
--- a/cypress/support/step_definitions/webpack.ts
+++ b/cypress/support/step_definitions/webpack.ts
@@ -1,12 +1,15 @@
+/// <reference types="Cypress" />
+
 import myAssertion from "./myAssertion";
 
 const {
-  given,
-  then
-} = require("cypress-cucumber-preprocessor/resolveStepDefinition");
+  Given,
+  Then
+} = require("cypress-cucumber-preprocessor/steps");
 
-given(`webpack is configured`, () => {});
+Given(`webpack is configured`, () => {});
 
-then(`this test should work just fine!`, () => {
+Then(`this test should work just fine!`, () => {
   myAssertion();
+  cy.visit('https://google.com')
 });

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^4.0.2",
-    "cypress": "^3.1.2",
+    "cypress": "^3.1.3",
     "cypress-cucumber-preprocessor": "^1.6.0",
-    "cypress-testing-library": "^2.3.3",
     "ts-loader": "^5.3.1",
-    "typescript": "^3.2.1"
+    "typescript": "^3.2.1",
+    "webpack": "^4.28.2"
   }
 }


### PR DESCRIPTION
notes:
- removes npm package "cypress-testing-library" in order to make things clearer, because it isn't being used
- adds npm package "webpack", which is needed for "npm run test" to work